### PR TITLE
Improve Coloring

### DIFF
--- a/addons/dialegume/DialegumeXmlSyntaxHighlighter.gd
+++ b/addons/dialegume/DialegumeXmlSyntaxHighlighter.gd
@@ -18,28 +18,45 @@ var _styles = {}
 func setup_styles():
 	_styles = {
 		"": {"color": Color(1, 1, 1)},
-		"tag": {"color": editor_settings.get_setting("text_editor/theme/highlighting/keyword_color")},
+		"tag": {"color": editor_settings.get_setting("text_editor/theme/highlighting/base_type_color")},
 		"tag.quote": {"color": editor_settings.get_setting("text_editor/theme/highlighting/string_color")},
 		"tag.attr": {"color": editor_settings.get_setting("text_editor/theme/highlighting/symbol_color")},
+		"error": {"color": editor_settings.get_setting("text_editor/theme/highlighting/brace_mismatch_color")},
+		"tag.comment": {"color": editor_settings.get_setting("text_editor/theme/highlighting/comment_color")},
 	}
 	update_cache()
 
 func _get_line_syntax_highlighting(line_number: int):
 	var line = get_text_edit().get_line(line_number)
-	if len(_styles) < 4:
-		editor_settings.settings_changed.connect(setup_styles)
+	if len(_styles) < 6:
+		if not editor_settings.settings_changed.is_connected(setup_styles):
+			editor_settings.settings_changed.connect(setup_styles)
 		setup_styles()
 	var highlights = {}
+	var in_comment = false
 	var in_tag = false
 	var in_quote = false
 	for char_num in range(len(line)):
 		var character = line[char_num]
-		if in_tag:
-			if character == ">":
-				highlights[char_num] = _styles["tag"]
-				highlights[char_num + 1] = _styles[""]
+		if in_comment:
+			if line.substr(char_num, 3) == "-->":
+				highlights[char_num + 3] = _styles[""]
 				in_tag = false
 				in_quote = false
+				in_comment = false
+		elif in_tag:
+			if character == ">":
+				if in_quote:
+					if line[max(char_num - 1, 0)] == "/":
+						highlights[char_num - 1] = _styles["error"]
+					else:
+						highlights[char_num] = _styles["error"]
+				else:
+					highlights[char_num] = _styles["tag"]
+					highlights[char_num + 1] = _styles[""]
+				in_tag = false
+				in_quote = false
+				in_comment = false
 			elif character == "\"":
 				if in_quote:
 					highlights[char_num + 1] = _styles["tag"]
@@ -47,11 +64,20 @@ func _get_line_syntax_highlighting(line_number: int):
 					highlights[char_num] = _styles["tag.quote"]
 				in_quote = not in_quote
 			elif character == " ":
-				highlights[char_num] = _styles["tag.attr"]
+				if in_quote:
+					pass
+				else:
+					highlights[char_num] = _styles["tag.attr"]
 			elif character == "/" and not in_quote:
 				highlights[char_num] = _styles["tag"]
 		else:
 			if character == "<":
+				if line.substr(char_num, 4) == "<!--":
+					in_comment = true
+					in_tag = false
+					in_quote = false
+					highlights[char_num] = _styles["tag.comment"]
+					continue
 				highlights[char_num] = _styles["tag"]
 				in_tag = true
 				in_quote = false

--- a/addons/dialegume/nodes/DialogBox.gd
+++ b/addons/dialegume/nodes/DialogBox.gd
@@ -198,7 +198,7 @@ func _decision_handler(tag: Dictionary):
 	var counter = 0
 	var default = -1
 	for branch in tag["_children"]:
-		print(branch)
+		#print(branch)
 		decision_box.add_item(branch["title"])
 		if branch["_active_bool"]:
 			if branch.get("default", false):


### PR DESCRIPTION
fixes #8 

Also adds red coloring to ending `>` or `/>` when quotes are not finished.

Also makes tags green so as to differentiate them from errors.