### PR TITLE
Add rate controls

### DIFF
--- a/addons/dialegume/nodes/DialogBox.gd
+++ b/addons/dialegume/nodes/DialogBox.gd
@@ -10,6 +10,7 @@ var waiting = false
 @export var line_delay = 1.0
 @export var delay_time = 1.0
 var current_line = 0
+var rate = 1.0
 
 signal entered_dialog
 signal exited_dialog
@@ -188,6 +189,7 @@ func _line_handler(tag: Dictionary):
 	else:
 		bs = tag.get("block_skip", "false")
 	block_skip = bs.to_lower().begins_with("t") or bs.to_lower().begins_with("y")
+	rate = float(tag.get("rate", tag.get("speed", "1.0")))
 	next_character()
 
 var current_decision = {}
@@ -473,7 +475,7 @@ func next_character(count = 0):
 				if count < character_count:
 					next_character(count)
 				else:
-					TextTimer.start(character_delay)
+					TextTimer.start(character_delay / rate)
 			else:
 				text_box.visible_characters -= 1
 				current_line += max_lines

--- a/addons/dialegume/sample/conversations/sample-dialog.tldr-dxml
+++ b/addons/dialegume/sample/conversations/sample-dialog.tldr-dxml
@@ -1,7 +1,7 @@
 <dialog display="client">
 <!-- Use narration tags to have a line that isn't read by a specific character. -->
 	<narration>The story, all names, characters, and incidents portrayed in this production are fictitious. No identification with actual persons (living or deceased), places, buildings, and products is intended or should be inferred.</narration>
-	<narration>This demo scene is made to demonstrate all of the functions available within Dialegume. It is recommended to not include the "sample" folder in your final project.</narration>
+	<narration>This demo scene is made to demonstrate all of the functions available within Dialegume. It is recommended to not include the "sample" folder in your final project export.</narration>
 	<narration>This demo scene is a heavily modified excerpt from a classic 1977 movie. Have fun figuring out what movie it is.</narration>
 
 <!-- Use enter tags to bring in new characters. -->
@@ -22,7 +22,7 @@
 	<line chr_id="PORCEN" inverted="true" emotion="default">I have something here for you. Your father wanted you to have this when you were old enough, but your aunt wouldn't allow it. She feared you might follow old Porcen Maceka on some damned-fool idealistic crusade like your father did.</line>
 <!-- Use move tags to rearrange characters on the screen -->
 	<move chr_id="NIKOLAI" side="right" priority="1"/>
-	<move chr_id="KYLE" side="left" priority="0"/>	syntax_highlighter.queue_free()
+	<move chr_id="KYLE" side="left" priority="0"/>
 	<line chr_id="NIKOLAI">Air breather, if you're done with me, I have some protection money to collect.</line>
 	<line chr_id="KYLE" emotion="surprised">Sure, you uh, you go do that.</line>
 <!-- Use exit tags to make a character leave the conversation -->
@@ -54,6 +54,8 @@
 		<branch id="branch_00_00" title="What was it like before the Chain Restaurants?">
 			<line chr_id="KYLE" emotion="default">What was it like before the [important type=Evil]Chain Restaurans[/important]?</line>
 			<line chr_id="PORCEN" emotion="frowning">The galaxy still wasn't perfect, but the [important type=Good]Baking Knights[/important] helped to keep peace, and ensured justice for all creatures.</line>
+			<line chr_id="KYLE" emotion="default">All creatures?</line>
+			<line chr_id="PORCEN" emotion="thoughtful">Well, we didn't always protect young men who ask too many questions...</line>
 <!-- Use the deactivate tag to deactivate previously active branches -->
 			<deactivate branch="branch_00_00" />
 <!-- Use jump tags to jump to another point in the conversation -->			
@@ -104,7 +106,9 @@
 		</branch>
 		<branch title="Terse">
 			<line chr_id="KYLE" emotion="laughing">Fine, old man.</line>
-			<line chr_id="PORCEN" emotion="frowning">The first things a Baker must learn are respect and kindness. That goes for all living things, even old men.</line>
+			<skip block="true" />
+			<line chr_id="PORCEN" emotion="frowning" rate="0.25">The first things a Baker must learn are respect, kindness, and patience. That goes for all living things, even old men.</line>
+			<skip block="false" />
 			<jump point="decision_01" />
 		</branch>
 	</decision>


### PR DESCRIPTION
closes #7

Adds rate controls that can be used in xml files. Rate controls are only relative for the time being, as there is no valid reason for them to be absolute, except to sync with audio or *maybe* in game events. Relative allows for global rate controls to work (for accessiblity), so they are the only supported form for now.